### PR TITLE
Fix Terminal

### DIFF
--- a/plugins/terminal/files/term.js
+++ b/plugins/terminal/files/term.js
@@ -112,7 +112,7 @@ function termInit(tid) {
     _term = $('#term');
 
     $(document).keypress(function (event) {
-        var ch = __filter_key(event, $.browser.mozilla);
+        var ch = __filter_key(event, navigator.userAgent.indexOf('Firefox') !== -1);
         if (event.which != 13)
             termSend(Base64.encode(ch));
         event.preventDefault();


### PR DESCRIPTION
jQuery 1.9 removes browser detection, so we use a different method because this is not something you can easily do a feature test for.
