### PR TITLE
Fix for "Certificate name is mandatory" error message on generator form cancel

### DIFF
--- a/genesis/plugins/certificates/main.py
+++ b/genesis/plugins/certificates/main.py
@@ -194,7 +194,9 @@ class CertificatesPlugin(CategoryPlugin):
 			if vars.getvalue('action', '') == 'OK':
 				pass
 		elif params[0] == 'dlgGen':
-			if vars.getvalue('certname', '') == '':
+			if vars.getvalue('action', '') == 'Cancel':
+				pass
+			elif vars.getvalue('certname', '') == '':
 				self.put_message('err', 'Certificate name is mandatory')
 			elif vars.getvalue('certname', '') in [x['name'] for x in self.certs]:
 				self.put_message('err', 'You already have a certificate with that name.')


### PR DESCRIPTION
Fix for issue cznweb/genesis#115

Message no longer appears, no matter what's in the fields.
