### PR TITLE
Fixed wrong parameter in change home for linux.

### DIFF
--- a/genesis/plugins/users/backend.py
+++ b/genesis/plugins/users/backend.py
@@ -118,7 +118,7 @@ class LinuxConfig(ModuleConfig):
     cmd_set_user_uid = 'usermod -u {0} {1}'
     cmd_set_user_gid = 'usermod -g {0} {1}'
     cmd_set_user_shell = 'usermod -s {0} {1}'
-    cmd_set_user_home = 'usermod -h {0} {1}'
+    cmd_set_user_home = 'usermod -d {0} {1}'
     cmd_set_group_gname = 'groupmod -n {0} {1}'
     cmd_set_group_ggid = 'groupmod -g {0} {1}'
     cmd_add_to_group = 'adduser {0} {1}'


### PR DESCRIPTION
You can't change the home directory in the user UI. Because of a wrong use of the usermod command. 
