### PR TITLE
fixed bug in check_conflict, used old? dependencie structure

### DIFF
--- a/genesis/plugmgr.py
+++ b/genesis/plugmgr.py
@@ -479,15 +479,15 @@ class RepositoryManager:
         if op == 'remove':
             for i in pdata:
                 for dep in pdata[i].deps:
-                    if dep[0] == 'plugin' and dep[1] == id and dep[1] in [x.id for x in self.installed]:
-                        raise ImSorryDave(pdata[dep[1]].name, pdata[i].name, op)
+                    if dep['type'] == 'plugin' and dep['package'] == id and dep['package'] in [x.id for x in self.installed]:
+                        raise ImSorryDave(pdata[dep['package']].name, pdata[i].name, op)
         elif op == 'install':
             t = self.list_available()
             try:
                 for i in t[id].deps:
-                    for dep in i[1]:
-                        if dep[0] == 'plugin' and dep[1] not in [x.id for x in self.installed]:
-                            raise ImSorryDave(t[id].name, t[dep[1]].name, op)
+                    for dep in t[id].deps[i]:
+                        if dep['type'] == 'plugin' and dep['package'] not in [x.id for x in self.installed]:
+                            raise ImSorryDave(t[id].name, t[dep['package']].name, op)
             except KeyError:
                 raise Exception('There was a problem in checking dependencies. '
                     'Please try again after refreshing the plugin list. '


### PR DESCRIPTION
This should fix https://github.com/cznweb/genesis/issues/230
In the genesis plugin documentation i read about the dependencie structure (https://arkos.io/dev/genesis/plugstruct) i think its outdated?
