### PR TITLE
Minor fix to firewall reinitialize error message

### DIFF
--- a/genesis/plugins/security/main.py
+++ b/genesis/plugins/security/main.py
@@ -80,7 +80,7 @@ class SecurityPlugin(apis.services.ServiceControlPlugin):
         if present == False:
             self.put_message('err', 'There may be a problem with your '
                 'firewall. Please reload the table by clicking "Reinitialize" '
-                'under the Settings tab below.')
+                'under the Settings tab above.')
 
         self._ranges = []
         for x in self.net_config.interfaces:


### PR DESCRIPTION
With the redesign in 0.6, the settings tab mentioned now appears above where the error message shows, rather than below it. This commit merely replaces it mentioning the Settings tab "below" with "above" to make it match what users actually see.
