### PR TITLE
Easing legibility by indicating 'Up to date' packages with checkbox i…

### DIFF
--- a/app/templates/packages.hbs
+++ b/app/templates/packages.hbs
@@ -14,7 +14,7 @@
         <div class="well">
             <h4><i class="fa fa-cube"></i> {{installed.length}} packages installed, {{upgradable.length}} can be upgraded.</h4>
         </div>
-        
+
         <div class="input-group">
             {{input type="text" class="form-control" value=installedQuery placeholder="Filter results"}}
             <span class="input-group-btn">
@@ -40,7 +40,7 @@
                             {{#if pkg.isUpgradable}}
                             <a href="#" {{bind-attr class=":btn :btn-success pkg.toRemove:disabled"}} {{action 'install' pkg}}><i class="fa fa-arrow-circle-up fa-fw"></i> Upgrade</a>
                             {{else}}
-                            <a href="#" class="btn btn-success disabled" {{action 'install' pkg}}><i class="fa fa-arrow-circle-up fa-fw"></i> Upgrade</a>
+                            <a href="#" class="btn btn-default disabled" {{action 'install' pkg}}><i class="fa fa-check-circle fa-fw"></i> Up to date</a>
                             {{/if}}
                             <a href="#" {{bind-attr class=":btn :btn-danger pkg.toInstall:disabled"}} {{action 'remove' pkg}}><i class="fa fa-times-circle fa-fw"></i> Uninstall</a>
                         </div>
@@ -65,7 +65,7 @@
                 <button class="btn btn-default" type="button" {{action 'clearAvailableFilter'}}><i class="fa fa-fw fa-times-circle"></i> Clear</button>
             </span>
         </div>
-        
+
         <table class="table">
             <tbody>
                 <tr>


### PR DESCRIPTION
Having green on every line, even with the two shades of green, makes it hard (for me at least) to quickly spot the packages which are upgradable.

This small change makes it easier and faster to read Genesis' packages page, by using a _white+disabled_ button when the package is 'up to date', and thereby only show a _green+actionable_ button for those packages which are upgradable.
